### PR TITLE
Readme bug fixed

### DIFF
--- a/07-class/README.md
+++ b/07-class/README.md
@@ -96,7 +96,7 @@ Coord operator+(const Coord &lh, const Coord &rh){
 }
 
 ostream& operator<<(ostream& out, const Coord &c){
-    out << c.re << ' ' << c.im;
+    out << c.x << ' ' << c.y;
     return out;
 }
 


### PR DESCRIPTION
Az ostream operator esetén, a Coord &c -nek csak x és y értékei vannak.
